### PR TITLE
[rvelaz] Added option to have an authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ custom:
     contentUrl: '<URL_TO_YOUR_HOSTED_SWAGGER_UI_FILES>' # REQUIRED
     name: '<your_custom_lambda_function_name>' # OPTIONAL - default = 'docs'
 ```
+### Authorizer
+
+If you are using AWS as a provider, you can define an authorizer for the docs function.
+
+```yaml
+custom:
+  documentation:
+    authorizer:
+      name: 'authorizer name' # REQUIRED
+      arn: '<ARN_OF_THE_AUTORIZER>' # REQUIRED. e.g. arn:aws:cognito-idp:us-east-1:1233:userpool/us-east-1_1
+```
+
 
 To load your `swagger.json` you need to add a `resolve.alias`.  
 E.g. for `webpack`:  

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class ServerlessPlugin {
     const name = `${this.serverless.service.serviceObject.name}-${this.options.stage}-docs`
     const handlerPath = `${packagePath}/docs.js`
     const functionName = this.config.name || 'docs'
+    const authorizer = this.config.authorizer
 
     const docsFunction = {
       [functionName]: {
@@ -52,6 +53,13 @@ class ServerlessPlugin {
           },
         },
       },
+    }
+
+    if (authorizer) {
+      docsFunction.docs.events[0].http.authorizer = {
+        name: authorizer.name,
+        arn: authorizer.arn
+      }
     }
 
     this.serverless.service.functions = Object.assign(this.serverless.service.functions, {}, docsFunction)


### PR DESCRIPTION
For cases where you don't want your API docs to be public, I have added an option to add an authorizer to the function that handles the documentation